### PR TITLE
update terraform-aws-modules/vpc/aws to a more recent version 

### DIFF
--- a/scripts/terraform/network.tf
+++ b/scripts/terraform/network.tf
@@ -79,7 +79,7 @@ data "aws_security_group" "default" {
 
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
-  version = "~> 2.57.0"
+  version = "~> 2.78.0"
 
   name = "otel-playground-vpc"
   cidr = "10.0.0.0/16"


### PR DESCRIPTION
Currently using the latest version of Terraform fails:
```
Error: Unsupported Terraform Core version
on .terraform/modules/vpc/versions.tf line 2, in terraform:
2:   required_version = ">= 0.12.7, < 0.14"
```

Updating terraform-aws-modules/vpc/aws to a more recent version fixes that.