### PR TITLE
Update aws-xray-sampling-spec.md to remove the invalid image

### DIFF
--- a/accessories/aws-xray-sampling-spec.md
+++ b/accessories/aws-xray-sampling-spec.md
@@ -5,8 +5,6 @@ To ensure efficient tracing and provide a representative sample of the requests 
 
 ## Workflow
 
-![X-Ray sampling workflow](https://shengxil.s3.amazonaws.com/SamplingWorkflow.png)
-
 In a distributed application, upon a client request arrives, the first traced service (entry service) is responsible for deciding whether the request will be traced or not. The decision will be propagated to all downstream services that participates in this distributed call. 
 
 ## Sampling Rule


### PR DESCRIPTION
*Issue #, if available:*
To fix the compliance of AWS internal security policies. (ticket not available to public view)

*Description of changes:*
AWS X-Ray team has received internal [ticket](https://t.corp.amazon.com/P98950956/overview) to remove the invalid image in X-Ray sampling readme doc, which violates Amazon Sec policies. 

This PR is to remove the image in `Workflow` section and only leave the text description.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

